### PR TITLE
preserved dungeon 1 state after monster encounter

### DIFF
--- a/JamCrawler/src/App.tsx
+++ b/JamCrawler/src/App.tsx
@@ -12,22 +12,24 @@ function App() {
     const [player, setPlayer] = useState<Player>({
         position: { x: 1, y: 1 },
         strength: 10,
-        stamina: 100,
+        defense: 2,
         health: 100,
-        luck: 0,
         inventory: [],
         isAlive: true,
+        experience: 0,
     });
     const [monster, setMonster] = useState<Monster>({
         position: { x: 1, y: 1 },
         strength: 10,
-        stamina: 100,
+        defense: 5,
         health: 100,
         luck: 0,
         inventory: [],
         isAlive: true,
     });
     const [dungeon, setDungeon] = useState<DungeonGrid>([]);
+    const [currDungeonNum, setCurrDungeonNum] = useState<number>(1);
+    const [level, setLevel] = useState<number>(1);
     return (
         <>
             <div>
@@ -48,6 +50,9 @@ function App() {
                             setMonster={setMonster}
                             dungeon={dungeon}
                             setDungeon={setDungeon}
+                            currDungeonNum={currDungeonNum}
+                            level={level}
+                            setLevel={setLevel}
                         />
                     )}
                     {currentAppState == "combat" && (

--- a/JamCrawler/src/components/Combat/CombatEncounter.tsx
+++ b/JamCrawler/src/components/Combat/CombatEncounter.tsx
@@ -74,6 +74,10 @@ export default function CombatEncounter({
             // TODO: give player experience
             // set larger popup text to display that monster was killed
             setLargeResults("You killed the monster!");
+            setMonster((prev) => ({
+                ...prev,
+                isAlive: false,
+            }));
             // unlock button to return to dungeon
             setPlayerCanReturn(true);
             monsterDead = true;

--- a/JamCrawler/src/components/Dungeon.tsx
+++ b/JamCrawler/src/components/Dungeon.tsx
@@ -1,33 +1,41 @@
 // src/components/Dungeon.tsx
-import React from 'react';
-import { DungeonGrid, Player, Monster } from '../types/types';
-import "./Dungeon.css"
-
+import React from "react";
+import { DungeonGrid, Player, Monster } from "../types/types";
+import "./Dungeon.css";
 
 type DungeonProps = {
-  dungeon: DungeonGrid;
-  player: Player;
-  monster: Monster;
+    dungeon: DungeonGrid;
+    player: Player;
+    monster: Monster;
 };
 
 const Dungeon: React.FC<DungeonProps> = ({ dungeon, player, monster }) => {
-  return (
-    <div className='dungeon'>
-      {dungeon.map((row, y) => (
-        <div key={y}>
-          {row.map((cell, x) => (
-            <span
-              key={`${x}-${y}`}
-              style={{ width: '20px', display: 'inline-block', textAlign: 'center' }}
-            >
-              {x === player.position.x && y === player.position.y ? '🧑‍🌾' :
-              x === monster.position.x && y === monster.position.y ? '🐍' : cell}
-            </span>
-          ))}
+    return (
+        <div className="dungeon">
+            {dungeon.map((row, y) => (
+                <div key={y}>
+                    {row.map((cell, x) => (
+                        <span
+                            key={`${x}-${y}`}
+                            style={{
+                                width: "20px",
+                                display: "inline-block",
+                                textAlign: "center",
+                            }}
+                        >
+                            {x === player.position.x && y === player.position.y
+                                ? "🧑‍🌾"
+                                : x === monster.position.x &&
+                                  y === monster.position.y &&
+                                  monster.isAlive
+                                ? "🐍"
+                                : cell}
+                        </span>
+                    ))}
+                </div>
+            ))}
         </div>
-      ))}
-    </div>
-  );
+    );
 };
 
 export default Dungeon;

--- a/JamCrawler/src/components/Game.tsx
+++ b/JamCrawler/src/components/Game.tsx
@@ -31,6 +31,9 @@ interface GameProps {
     setDungeon: (
         value: DungeonGrid | ((prevValue: DungeonGrid) => DungeonGrid)
     ) => void;
+    currDungeonNum: number;
+    level: number;
+    setLevel: (value: number | ((prevValue: number) => number)) => void;
 }
 
 export default function Game({
@@ -41,18 +44,12 @@ export default function Game({
     setMonster,
     dungeon,
     setDungeon,
+    currDungeonNum,
+    level,
+    setLevel,
 }: GameProps) {
-    const [level, setLevel] = useState<number>(1);
-
-    // put this up one level?
-    const [combatResult, setCombatResult] = useState<string | null>(null);
-
     const [todos, setTodos] = useState<Todo[]>([]);
-
     const generateDungeon = () => {
-        // RIVER-Trying out adding logs for visibility on function execution
-        console.log("Generating dungeon for first level...");
-
         const newDungeon = Array.from({ length: GRID_SIZE }, () =>
             Array(GRID_SIZE).fill(EMPTY_CHAR)
         );
@@ -66,35 +63,19 @@ export default function Game({
         }
 
         // Set dungeon without items for level 1
+        /*
         console.log("Dungeon setup complete for level 1.");
         setDungeon(newDungeon);
-
-        // RIVER-This resets the player's stats and places player on map
-        // Setting player in a fixed starting point for now, but monster
-        // will be random
-        setPlayer({
-            position: { x: 1, y: 1 },
-            strength: 10,
-            defense: 100,
-            health: 100,
-            experience: 0,
-            inventory: [],
-            isAlive: true,
-        });
+        */
 
         // RIVER-This generates monster to map ONCE at random coordinates
         const monsterX = Math.floor(Math.random() * (GRID_SIZE - 2)) + 1;
         const monsterY = Math.floor(Math.random() * (GRID_SIZE - 2)) + 1;
 
-        setMonster({
+        setMonster((prev) => ({
+            ...prev,
             position: { x: monsterX, y: monsterY },
-            strength: 10,
-            defense: 5,
-            health: 50,
-            luck: 1000,
-            inventory: [],
-            isAlive: true,
-        });
+        }));
         console.log("Monster placed at (${monsterX}, ${monsterY})");
 
         // RIVER-Adding one sword and two potions to level 1
@@ -157,8 +138,12 @@ export default function Game({
     };
 
     useEffect(() => {
-        generateDungeon();
-    }, [level]);
+        if (currDungeonNum == level) {
+            console.log("generating new dungeon");
+            generateDungeon();
+            setLevel((prev) => prev + 1);
+        }
+    }, []);
 
     const movePlayer = (dx: number, dy: number) => {
         let combatNewPos = {
@@ -272,7 +257,7 @@ export default function Game({
                 </div>
 
                 <div className="dungeon-container column-2">
-                    <h2>Level {level}</h2>
+                    <h2>Level {currDungeonNum}</h2>
                     <Dungeon
                         dungeon={dungeon}
                         player={player}

--- a/JamCrawler/src/components/Title Screen/TitleScreen.tsx
+++ b/JamCrawler/src/components/Title Screen/TitleScreen.tsx
@@ -11,7 +11,7 @@ export default function TitleScreen({ setCurrentAppState }: Props) {
     const titleScreenSource = "./Bessie.webp";
     const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
         const currTarget = e.target as HTMLButtonElement;
-        console.log(e);
+        //console.log(e);
         if (currTarget.id == "start") {
             setCurrentAppState("introSplash");
         }
@@ -22,8 +22,8 @@ export default function TitleScreen({ setCurrentAppState }: Props) {
             <div className="main-title">Get it Done-geon</div>
             <img alt="picture of game title screen" src={titleScreenSource} />
             <p className="text-xl mb-4 text-center max-w-md font-Helvetica Neue">
-            ARE YOU READY FOR THE ADVENTURE TO BEGIN?
-            </p>            
+                ARE YOU READY FOR THE ADVENTURE TO BEGIN?
+            </p>
             <div className="flex flex-row buttons-row">
                 <button
                     className="start-button"


### PR DESCRIPTION
The player now correctly returns to dungeon 1 after finishing the monster encounter instead of generating a new dungeon